### PR TITLE
make writing of image data concurrent

### DIFF
--- a/globals/data.go
+++ b/globals/data.go
@@ -1,8 +1,13 @@
 package globals
 
-import "embed"
+import (
+	"embed"
+	"sync"
+)
 
 //go:embed fonts/*
 var Fonts embed.FS
 
 var File []byte
+
+var ImageSync sync.WaitGroup

--- a/pdf/pdf.go
+++ b/pdf/pdf.go
@@ -179,6 +179,7 @@ func FromAst(md ast.Node) *spec.PDF {
 	}
 	cli.Other("\n")
 	parsed := time.Now()
+	globals.ImageSync.Wait()
 	cli.Other("Added %v elements in %v\n", i, parsed.Sub(start))
 
 	headings := make([]*elements.Heading, 0)

--- a/pdf/spec/image.go
+++ b/pdf/spec/image.go
@@ -28,14 +28,18 @@ func NewImageObject(iData image.Image, iName string, mul float64) (XObject, Adda
 	x.Dictionary.Set("Height", iData.Bounds().Dy()/pixelMul)
 	x.Dictionary.Set("ColorSpace", "/DeviceRGB")
 	x.Dictionary.Set("BitsPerComponent", 8)
-	for j := 0; j < iData.Bounds().Dy()/pixelMul; j++ {
-		for k := 0; k < iData.Bounds().Dx()/pixelMul; k++ {
-			r, g, b, _ := iData.At(k*pixelMul, j*pixelMul).RGBA()
-			x.Write([]byte{byte(r >> 8), byte(g >> 8), byte(b >> 8)})
+	go func(obj *XObject) {
+		globals.ImageSync.Add(1)
+		defer globals.ImageSync.Done()
+		for j := 0; j < iData.Bounds().Dy()/pixelMul; j++ {
+			for k := 0; k < iData.Bounds().Dx()/pixelMul; k++ {
+				r, g, b, _ := iData.At(k*pixelMul, j*pixelMul).RGBA()
+				obj.Write([]byte{byte(r >> 8), byte(g >> 8), byte(b >> 8)})
+			}
 		}
-	}
-	x.WriteString("\n")
-	x.Set("Size", x.Len())
+		obj.WriteString("\n")
+		obj.Set("Size", x.Len())
+	}(&x)
 	ia := ImageAddable{
 		ImageName: x.Name,
 		W:         float64(iData.Bounds().Dx()),


### PR DESCRIPTION
images took a long time if present, now it doesn't matter as much how many images there are because writing each individual pixel into the xobject stream is concurrent