### PR TITLE
Graphviz black

### DIFF
--- a/globals/version.go
+++ b/globals/version.go
@@ -1,3 +1,3 @@
 package globals
 
-const Version = "2.7.1"
+const Version = "2.7.2"

--- a/pdf/spec/image.go
+++ b/pdf/spec/image.go
@@ -28,18 +28,18 @@ func NewImageObject(iData image.Image, iName string, mul float64) (XObject, Adda
 	x.Dictionary.Set("Height", iData.Bounds().Dy()/pixelMul)
 	x.Dictionary.Set("ColorSpace", "/DeviceRGB")
 	x.Dictionary.Set("BitsPerComponent", 8)
-	go func(obj *XObject) {
-		globals.ImageSync.Add(1)
-		defer globals.ImageSync.Done()
-		for j := 0; j < iData.Bounds().Dy()/pixelMul; j++ {
-			for k := 0; k < iData.Bounds().Dx()/pixelMul; k++ {
-				r, g, b, _ := iData.At(k*pixelMul, j*pixelMul).RGBA()
-				obj.Write([]byte{byte(r >> 8), byte(g >> 8), byte(b >> 8)})
-			}
+	//go func(obj *XObject) {
+	//	globals.ImageSync.Add(1)
+	//	defer globals.ImageSync.Done()
+	for j := 0; j < iData.Bounds().Dy()/pixelMul; j++ {
+		for k := 0; k < iData.Bounds().Dx()/pixelMul; k++ {
+			r, g, b, _ := iData.At(k*pixelMul, j*pixelMul).RGBA()
+			x.Write([]byte{byte(r >> 8), byte(g >> 8), byte(b >> 8)})
 		}
-		obj.WriteString("\n")
-		obj.Set("Size", x.Len())
-	}(&x)
+	}
+	x.WriteString("\n")
+	x.Set("Size", x.Len())
+	//}(&x)
 	ia := ImageAddable{
 		ImageName: x.Name,
 		W:         float64(iData.Bounds().Dx()),


### PR DESCRIPTION
### 2.7.2
- Chore: version bump to 2.7.2

### Fixes
- Removed image concurrency to mitigate issues with image syncing (commit 741719f)

### Refactoring
- Switched to encoding/json library from go-json library (commit bbbff2f)

Note: The removed image concurrency is a temporary fix and will be improved later.