### PR TITLE
chore: temporary fix

### DIFF
--- a/pdf/spec/justification.go
+++ b/pdf/spec/justification.go
@@ -58,6 +58,9 @@ func escape(str string) (ret string) {
 	ret = strings.ReplaceAll(str, "\\", "\\\\")
 	ret = strings.ReplaceAll(ret, "(", "\\(")
 	ret = strings.ReplaceAll(ret, ")", "\\)")
+	ret = strings.ReplaceAll(ret, "“", "\"")
+	ret = strings.ReplaceAll(ret, "„", "\"")
+	ret = strings.ReplaceAll(ret, "”", "\"")
 	return
 }
 


### PR DESCRIPTION
This commit adds temporary escape sequences to handle the characters “, „, and ” in the justification function of the PDF library. This is a temporary fix to ensure that these characters do not cause errors in the code.